### PR TITLE
Added Custom hash for unordered map

### DIFF
--- a/D_Make_a_Power_of_Two.cpp
+++ b/D_Make_a_Power_of_Two.cpp
@@ -90,6 +90,26 @@ void dnl(){
     cout<<nl;
 }
 
+struct custom_hash {
+    static uint64_t splitmix64(uint64_t x) {
+	// use the below link for further help
+	// http://xorshift.di.unimi.it/splitmix64.c
+	x += 0x9e3779b97f4a7c15;
+	x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9;
+	x = (x ^ (x >> 27)) * 0x94d049bb133111eb;
+	return x ^ (x >> 31);
+    }
+
+    size_t operator()(uint64_t x) const {
+	static const uint64_t FIXED_RANDOM = chrono::steady_clock::now().time_since_epoch().count();
+	return splitmix64(x + FIXED_RANDOM);
+    }
+};
+
+// now use the below lines to implement unordered map using the custom hash
+// unordered_map<long long, int, custom_hash> safe_map;
+// gp_hash_table<long long, int, custom_hash> safe_hash_table;
+
 int lcs(string X, string Y, int m, int n)
 {
     int L[m + 1][n + 1];


### PR DESCRIPTION
As unordered map works on hashing which is O(1) in average cases but sometimes problem setters design test cases in coding contests in such a manner that the normal unordered map goes in worst case i.e. O(N). So, this custom hash is to eliminate that chance. It runs in O(1) in all cases.